### PR TITLE
Make the links clickable in React template

### DIFF
--- a/templates/react-ts/src/App.css
+++ b/templates/react-ts/src/App.css
@@ -70,6 +70,10 @@ header {
   pointer-events: none;
 }
 
+.overlay a {
+  pointer-events: auto;
+}
+
 .overlay > .grow {
   flex-grow: 1;
 }


### PR DESCRIPTION
`pointer-events: none` in the `.overlay` CSS class prevented the links from being clickable. Added an exception for the links `<a/>`.