### PR TITLE
fix: support root skills releases

### DIFF
--- a/.github/workflows/skills.yml
+++ b/.github/workflows/skills.yml
@@ -41,9 +41,13 @@ jobs:
                   echo "Latest skills tag: $latest"
                   tmp=$(mktemp -d)
                   git clone --depth 1 --branch "$latest" https://github.com/playcanvas/skills.git "$tmp"
+                  source="$tmp/skills"
+                  if [ ! -d "$source" ]; then
+                      source="$tmp/plugins/engine/skills"
+                  fi
                   rm -rf skills
                   mkdir -p skills
-                  cp -R "$tmp/plugins/engine/skills/." skills/
+                  cp -R "$source/." skills/
                   rm -rf "$tmp"
                   echo "ref=$latest" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

Support both the original nested PlayCanvas Skills release layout and the canonical root skills directory used by new releases.

## Manual smoke test

1. Dispatch Update Skills against the existing release and expect the workflow to resolve all 12 skills without changing their contents.
2. Dispatch it after a root-layout PlayCanvas Skills release and expect the workflow to copy all 12 skills and open or update the generated skills PR.