### PR TITLE
fix: accept skills release events

### DIFF
--- a/.github/workflows/skills.yml
+++ b/.github/workflows/skills.yml
@@ -2,6 +2,9 @@ name: Update Skills
 
 on:
     workflow_dispatch:
+    repository_dispatch:
+        types:
+            - skills-release
 
 permissions:
     contents: write


### PR DESCRIPTION
Accept repository dispatch events from the skills release workflow while retaining manual dispatch support. This uses the GitHub App repository permission already required by the sync job.\n\nManual smoke test:\n\n1. Publish a PlayCanvas skills prerelease; expect Update Skills to start in create-playcanvas.\n2. With vendored skills already current, expect the workflow to finish without opening a duplicate pull request.