### PR TITLE
Update web components templates for @playcanvas/web-components 0.17.0

### DIFF
--- a/templates/web-components/base/README.md
+++ b/templates/web-components/base/README.md
@@ -39,9 +39,9 @@ so `document.querySelector` reaches them and `setAttribute` changes them.
 
 `src/main.ts` covers the two things HTML alone cannot do:
 
-- **Attaching engine scripts.** `<pc-script name="...">` resolves scripts that `<pc-asset>` fetched at
-  runtime. Scripts imported through the bundler — like `CameraControls` and `Grid` here — are attached
-  through the entity instead, reached via `whenReady()` and the element's `.entity` property.
+- **Attaching engine scripts.** `<pc-script-instance name="...">` resolves scripts that `<pc-asset>`
+  fetched at runtime. Scripts imported through the bundler — like `CameraControls` and `Grid` here — are
+  attached through the entity instead, reached via `whenReady()` and the element's `.entity` property.
 - **Responding to pointer input.** `<pc-app>` picks whatever is under the pointer and dispatches an
   ordinary `PointerEvent` on the `<pc-entity>` it hit, so `addEventListener('pointerup', ...)` works on a
   3D entity exactly as it would on a `<button>`. Events are only generated for entities that have a

--- a/templates/web-components/base/package.json
+++ b/templates/web-components/base/package.json
@@ -15,7 +15,7 @@
         "typecheck": "tsc --noEmit"
     },
     "dependencies": {
-        "@playcanvas/web-components": "^0.16.0",
+        "@playcanvas/web-components": "^0.17.0",
         "playcanvas": "^2.21.4"
     },
     "devDependencies": {

--- a/templates/web-components/first-person-controller/index.html
+++ b/templates/web-components/first-person-controller/index.html
@@ -14,12 +14,12 @@
             <pc-material id="green-material" diffuse="#2e6638" emissive="#09140b" gloss="0.2"></pc-material>
             <pc-material id="wood-material" diffuse="#7a451a" emissive="#180e05" gloss="0.2"></pc-material>
             <pc-material id="metal-material" diffuse="#475461" emissive="#0e1113" gloss="0.5"></pc-material>
-            <pc-module
+            <pc-wasm
                 name="Ammo"
                 glue="/ammo/ammo.wasm.js"
                 wasm="/ammo/ammo.wasm.wasm"
                 fallback="/ammo/ammo.js"
-            ></pc-module>
+            ></pc-wasm>
             <pc-scene>
                 <pc-entity name="light" rotation="50 30 0"
                     ><pc-light
@@ -36,121 +36,121 @@
                 <pc-entity name="floor" position="0 -0.1 0" scale="18 0.2 18"
                     ><pc-render type="box" material="floor-material"></pc-render
                     ><pc-collision type="box" half-extents="9 0.1 9"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="back-wall" position="0 1.5 -9" scale="18 3 0.3"
                     ><pc-render type="box" material="wall-material"></pc-render
                     ><pc-collision type="box" half-extents="9 1.5 0.15"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="front-wall" position="0 1.5 9" scale="18 3 0.3"
                     ><pc-render type="box" material="wall-material"></pc-render
                     ><pc-collision type="box" half-extents="9 1.5 0.15"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="left-wall" position="-9 1.5 0" scale="0.3 3 18"
                     ><pc-render type="box" material="wall-material"></pc-render
                     ><pc-collision type="box" half-extents="0.15 1.5 9"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="right-wall" position="9 1.5 0" scale="0.3 3 18"
                     ><pc-render type="box" material="wall-material"></pc-render
                     ><pc-collision type="box" half-extents="0.15 1.5 9"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="blue-crate" position="-2 0.75 -3" scale="1.5 1.5 1.5"
                     ><pc-render type="box" material="blue-material"></pc-render
                     ><pc-collision type="box" half-extents="0.75 0.75 0.75"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="green-crate" position="3 0.5 1" scale="2.5 1 1"
                     ><pc-render type="box" material="green-material"></pc-render
                     ><pc-collision type="box" half-extents="1.25 0.5 0.5"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="cargo-left-0" position="-5.5 0.75 -5.5" scale="2 1.5 2"
                     ><pc-render type="box" material="wood-material"></pc-render
                     ><pc-collision type="box" half-extents="1 0.75 1"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="cargo-left-1" position="-5.5 2 -5.5" scale="1.5 1 1.5"
                     ><pc-render type="box" material="blue-material"></pc-render
                     ><pc-collision type="box" half-extents="0.75 0.5 0.75"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="cargo-right-0" position="5.3 0.6 -4.8" scale="2.4 1.2 2"
                     ><pc-render type="box" material="green-material"></pc-render
                     ><pc-collision type="box" half-extents="1.2 0.6 1"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="cargo-right-1" position="5.3 1.7 -4.8" scale="1.5 1 1.5"
                     ><pc-render type="box" material="wood-material"></pc-render
                     ><pc-collision type="box" half-extents="0.75 0.5 0.75"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="cargo-center" position="0 0.6 -6.5" scale="2.2 1.2 1.8"
                     ><pc-render type="box" material="blue-material"></pc-render
                     ><pc-collision type="box" half-extents="1.1 0.6 0.9"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="shelf-left-post-0" position="-6.8 1.4 -3.5" scale="0.25 2.8 0.25"
                     ><pc-render type="box" material="metal-material"></pc-render
                     ><pc-collision type="box" half-extents="0.125 1.4 0.125"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="shelf-left-post-1" position="-6.8 1.4 0" scale="0.25 2.8 0.25"
                     ><pc-render type="box" material="metal-material"></pc-render
                     ><pc-collision type="box" half-extents="0.125 1.4 0.125"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="shelf-left-post-2" position="-6.8 1.4 3.5" scale="0.25 2.8 0.25"
                     ><pc-render type="box" material="metal-material"></pc-render
                     ><pc-collision type="box" half-extents="0.125 1.4 0.125"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="shelf-right-post-0" position="6.8 1.4 -3.5" scale="0.25 2.8 0.25"
                     ><pc-render type="box" material="metal-material"></pc-render
                     ><pc-collision type="box" half-extents="0.125 1.4 0.125"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="shelf-right-post-1" position="6.8 1.4 0" scale="0.25 2.8 0.25"
                     ><pc-render type="box" material="metal-material"></pc-render
                     ><pc-collision type="box" half-extents="0.125 1.4 0.125"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="shelf-right-post-2" position="6.8 1.4 3.5" scale="0.25 2.8 0.25"
                     ><pc-render type="box" material="metal-material"></pc-render
                     ><pc-collision type="box" half-extents="0.125 1.4 0.125"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="shelf-left-low" position="-6.8 0.65 0" scale="1.1 0.18 7.5"
                     ><pc-render type="box" material="metal-material"></pc-render
                     ><pc-collision type="box" half-extents="0.55 0.09 3.75"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="shelf-left-high" position="-6.8 2.1 0" scale="1.1 0.18 7.5"
                     ><pc-render type="box" material="metal-material"></pc-render
                     ><pc-collision type="box" half-extents="0.55 0.09 3.75"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="shelf-right-low" position="6.8 0.65 0" scale="1.1 0.18 7.5"
                     ><pc-render type="box" material="metal-material"></pc-render
                     ><pc-collision type="box" half-extents="0.55 0.09 3.75"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="shelf-right-high" position="6.8 2.1 0" scale="1.1 0.18 7.5"
                     ><pc-render type="box" material="metal-material"></pc-render
                     ><pc-collision type="box" half-extents="0.55 0.09 3.75"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="pallet" position="-2.5 0.15 2.5" scale="3 0.3 2"
                     ><pc-render type="box" material="wood-material"></pc-render
                     ><pc-collision type="box" half-extents="1.5 0.15 1"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="player" position="0 1 5">
                     <pc-collision type="capsule" radius="0.45" height="1.8"></pc-collision>
-                    <pc-rigidbody type="dynamic" mass="80" angular-factor="0 0 0"></pc-rigidbody>
+                    <pc-rigid-body type="dynamic" mass="80" angular-factor="0 0 0"></pc-rigid-body>
                     <pc-entity name="camera" position="0 0.65 0"
                         ><pc-camera clear-color="#61a3db" fov="80"></pc-camera
                     ></pc-entity>

--- a/templates/web-components/first-person-controller/src/main.ts
+++ b/templates/web-components/first-person-controller/src/main.ts
@@ -6,7 +6,7 @@ import './starter.css';
 
 await Promise.all([
     whenReady('pc-entity[name="player"] > pc-collision'),
-    whenReady('pc-entity[name="player"] > pc-rigidbody')
+    whenReady('pc-entity[name="player"] > pc-rigid-body')
 ]);
 const [player, camera] = await Promise.all([
     whenReady<EntityElement>('pc-entity[name="player"]'),

--- a/templates/web-components/interactive-sphere/src/main.ts
+++ b/templates/web-components/interactive-sphere/src/main.ts
@@ -47,7 +47,7 @@ if (skyboxLayer) {
 }
 
 // Engine scripts are resolved by the bundler, so they are attached through the entity rather than
-// with <pc-script name="...">, which only resolves scripts fetched at runtime by <pc-asset>
+// with <pc-script-instance name="...">, which only resolves scripts fetched at runtime by <pc-asset>
 const camera = cameraComponent.closestEntity;
 camera?.entity?.addComponent('script');
 camera?.entity?.script?.create(CameraControls, { properties: { sceneSize: 3 } });

--- a/templates/web-components/model-viewer/src/main.ts
+++ b/templates/web-components/model-viewer/src/main.ts
@@ -14,7 +14,7 @@ const [cameraComponent, sky] = await Promise.all([
 ]);
 
 // Engine scripts are resolved by the bundler, so they are attached through the entity rather than
-// with <pc-script name="...">, which only resolves scripts fetched at runtime by <pc-asset>
+// with <pc-script-instance name="...">, which only resolves scripts fetched at runtime by <pc-asset>
 const camera = cameraComponent.closestEntity;
 camera?.entity?.addComponent('script');
 camera?.entity?.script?.create(CameraControls, { properties: { sceneSize: 2.5 } });

--- a/templates/web-components/physics-playground/index.html
+++ b/templates/web-components/physics-playground/index.html
@@ -8,12 +8,12 @@
     </head>
     <body>
         <pc-app>
-            <pc-module
+            <pc-wasm
                 name="Ammo"
                 glue="/ammo/ammo.wasm.js"
                 wasm="/ammo/ammo.wasm.wasm"
                 fallback="/ammo/ammo.js"
-            ></pc-module>
+            ></pc-wasm>
             <pc-material id="floor-material" diffuse="#2e333d" gloss="0.2"></pc-material>
             <pc-material id="cyan-material" diffuse="#29ade6" gloss="0.45"></pc-material>
             <pc-material id="coral-material" diffuse="#f25738" gloss="0.45"></pc-material>
@@ -34,7 +34,7 @@
                 <pc-entity name="floor" position="0 -0.1 0" scale="10 0.2 10"
                     ><pc-render type="box" material="floor-material"></pc-render
                     ><pc-collision type="box" half-extents="5 0.1 5"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity id="bodies"></pc-entity>
             </pc-scene>

--- a/templates/web-components/physics-playground/src/main.ts
+++ b/templates/web-components/physics-playground/src/main.ts
@@ -18,7 +18,7 @@ const spawn = () => {
     const type = TYPES[i % TYPES.length];
     bodies.insertAdjacentHTML(
         'beforeend',
-        `<pc-entity data-body position="${((i % 4) - 1.5) * 1.1} ${0.7 + Math.floor(i / 4) * 1.1} ${(Math.floor(i / 4) - 1) * 1.4}" rotation="${i * 13} ${i * 29} 0" scale="${SCALES[i % SCALES.length]}"><pc-render type="${type}" material="${MATERIALS[i % MATERIALS.length]}"></pc-render><pc-collision type="${type}"></pc-collision><pc-rigidbody type="dynamic" mass="1" restitution="0.35"></pc-rigidbody></pc-entity>`
+        `<pc-entity data-body position="${((i % 4) - 1.5) * 1.1} ${0.7 + Math.floor(i / 4) * 1.1} ${(Math.floor(i / 4) - 1) * 1.4}" rotation="${i * 13} ${i * 29} 0" scale="${SCALES[i % SCALES.length]}"><pc-render type="${type}" material="${MATERIALS[i % MATERIALS.length]}"></pc-render><pc-collision type="${type}"></pc-collision><pc-rigid-body type="dynamic" mass="1" restitution="0.35"></pc-rigid-body></pc-entity>`
     );
 };
 const reset = () => {

--- a/templates/web-components/product-configurator/src/main.ts
+++ b/templates/web-components/product-configurator/src/main.ts
@@ -58,8 +58,10 @@ ground.addComponent('render', {
     receiveShadows: true
 });
 
+// The element's entity is a host whose transform composes with the GLB's authored root rotation
+// (a -90° X up-axis fix), so only the yaw is set here
 const entity = model.entity!;
-entity.setLocalEulerAngles(-90, -25, 0);
+entity.setLocalEulerAngles(0, -25, 0);
 entity.root.syncHierarchy();
 const meshes = (entity.findComponents('render') as RenderComponent[]).flatMap((render) => render.meshInstances);
 const bounds = meshes[0].aabb.clone();

--- a/templates/web-components/spinning-cube/src/main.ts
+++ b/templates/web-components/spinning-cube/src/main.ts
@@ -14,7 +14,7 @@ class Rotate extends Script {
 }
 
 // Engine scripts are resolved by the bundler, so they are attached through the entity rather than
-// with <pc-script name="...">, which only resolves scripts fetched at runtime by <pc-asset>
+// with <pc-script-instance name="...">, which only resolves scripts fetched at runtime by <pc-asset>
 const cube = await whenReady<EntityElement>('pc-entity[name="cube"]');
 
 cube.entity?.addComponent('script');

--- a/templates/web-components/splat-viewer/src/main.ts
+++ b/templates/web-components/splat-viewer/src/main.ts
@@ -9,7 +9,7 @@ import './style.css';
 const cameraComponent = await whenReady('pc-camera');
 
 // Engine scripts are resolved by the bundler, so they are attached through the entity rather than
-// with <pc-script name="...">, which only resolves scripts fetched at runtime by <pc-asset>
+// with <pc-script-instance name="...">, which only resolves scripts fetched at runtime by <pc-asset>
 const camera = cameraComponent.closestEntity;
 camera?.entity?.addComponent('script');
 camera?.entity?.script?.create(CameraControls, { properties: { sceneSize: 2 } });

--- a/templates/web-components/third-person-controller/index.html
+++ b/templates/web-components/third-person-controller/index.html
@@ -16,12 +16,12 @@
             <pc-material id="shirt-material" diffuse="#268bd2"></pc-material>
             <pc-material id="skin-material" diffuse="#c78759"></pc-material>
             <pc-material id="pants-material" diffuse="#2e4a85"></pc-material>
-            <pc-module
+            <pc-wasm
                 name="Ammo"
                 glue="/ammo/ammo.wasm.js"
                 wasm="/ammo/ammo.wasm.wasm"
                 fallback="/ammo/ammo.js"
-            ></pc-module>
+            ></pc-wasm>
             <pc-scene>
                 <pc-entity name="camera" position="0 3 6"><pc-camera clear-color="#7ab8e6"></pc-camera></pc-entity>
                 <pc-entity name="light" rotation="45 30 0"
@@ -36,32 +36,32 @@
                 <pc-entity name="ground" position="0 -0.1 0" scale="20 0.2 20"
                     ><pc-render type="box" material="ground-material"></pc-render
                     ><pc-collision type="box" half-extents="10 0.1 10"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="block-0" position="-4.5 0.5 -3.5" scale="2.4 1 2.4"
                     ><pc-render type="box" material="block-material"></pc-render
                     ><pc-collision type="box" half-extents="1.2 0.5 1.2"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="block-1" position="4.2 0.5 -2.8" rotation="0 25 0" scale="2.4 1 2.4"
                     ><pc-render type="box" material="block-material"></pc-render
                     ><pc-collision type="box" half-extents="1.2 0.5 1.2"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="block-2" position="-3.7 0.5 3.2" rotation="0 50 0" scale="2.4 1 2.4"
                     ><pc-render type="box" material="block-material"></pc-render
                     ><pc-collision type="box" half-extents="1.2 0.5 1.2"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="block-3" position="3.8 0.5 3.6" rotation="0 75 0" scale="2.4 1 2.4"
                     ><pc-render type="box" material="block-material"></pc-render
                     ><pc-collision type="box" half-extents="1.2 0.5 1.2"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="tree-0-trunk" position="-7 0.99 -6" scale="0.418 1.98 0.418"
                     ><pc-render type="box" material="wood-material"></pc-render
                     ><pc-collision type="box" half-extents="0.209 0.99 0.209"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="tree-0-crown-0" position="-7 2.09 -6" scale="2.31 1.98 2.31"
                     ><pc-render type="cone" material="leaves-material"></pc-render
@@ -75,7 +75,7 @@
                 <pc-entity name="tree-1-trunk" position="6.5 1.125 -6.5" scale="0.475 2.25 0.475"
                     ><pc-render type="box" material="wood-material"></pc-render
                     ><pc-collision type="box" half-extents="0.2375 1.125 0.2375"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="tree-1-crown-0" position="6.5 2.375 -6.5" scale="2.625 2.25 2.625"
                     ><pc-render type="cone" material="leaves-material"></pc-render
@@ -89,7 +89,7 @@
                 <pc-entity name="tree-2-trunk" position="-7.5 0.81 5" scale="0.342 1.62 0.342"
                     ><pc-render type="box" material="wood-material"></pc-render
                     ><pc-collision type="box" half-extents="0.171 0.81 0.171"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="tree-2-crown-0" position="-7.5 1.71 5" scale="1.89 1.62 1.89"
                     ><pc-render type="cone" material="leaves-material"></pc-render
@@ -103,7 +103,7 @@
                 <pc-entity name="tree-3-trunk" position="7 1.035 5.5" scale="0.437 2.07 0.437"
                     ><pc-render type="box" material="wood-material"></pc-render
                     ><pc-collision type="box" half-extents="0.2185 1.035 0.2185"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="tree-3-crown-0" position="7 2.185 5.5" scale="2.415 2.07 2.415"
                     ><pc-render type="cone" material="leaves-material"></pc-render
@@ -117,7 +117,7 @@
                 <pc-entity name="tree-4-trunk" position="-2.2 0.765 -8" scale="0.323 1.53 0.323"
                     ><pc-render type="box" material="wood-material"></pc-render
                     ><pc-collision type="box" half-extents="0.1615 0.765 0.1615"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="tree-4-crown-0" position="-2.2 1.615 -8" scale="1.785 1.53 1.785"
                     ><pc-render type="cone" material="leaves-material"></pc-render
@@ -131,16 +131,16 @@
                 <pc-entity name="fallen-log" position="0 0.35 6" scale="3.8 0.7 0.7"
                     ><pc-render type="box" material="wood-material"></pc-render
                     ><pc-collision type="box" half-extents="1.9 0.35 0.35"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="stump" position="-1.8 0.4 -2.2" scale="0.9 0.8 0.9"
                     ><pc-render type="box" material="wood-material"></pc-render
                     ><pc-collision type="box" half-extents="0.45 0.4 0.45"></pc-collision
-                    ><pc-rigidbody type="static"></pc-rigidbody
+                    ><pc-rigid-body type="static"></pc-rigid-body
                 ></pc-entity>
                 <pc-entity name="player" position="0 1.1 0">
                     <pc-collision type="capsule" radius="0.5" height="2.4" linear-offset="0 0.1 0"></pc-collision>
-                    <pc-rigidbody type="dynamic" mass="70" angular-factor="0 0 0"></pc-rigidbody>
+                    <pc-rigid-body type="dynamic" mass="70" angular-factor="0 0 0"></pc-rigid-body>
                     <pc-entity name="character" position="0 0.2 0">
                         <pc-entity name="body" scale="0.56 0.88 0.38"
                             ><pc-render type="box" material="shirt-material"></pc-render

--- a/templates/web-components/third-person-controller/src/main.ts
+++ b/templates/web-components/third-person-controller/src/main.ts
@@ -6,7 +6,7 @@ import './starter.css';
 
 await Promise.all([
     whenReady('pc-entity[name="player"] > pc-collision'),
-    whenReady('pc-entity[name="player"] > pc-rigidbody')
+    whenReady('pc-entity[name="player"] > pc-rigid-body')
 ]);
 const [player, camera, model] = await Promise.all([
     whenReady<EntityElement>('pc-entity[name="player"]'),


### PR DESCRIPTION
## What

Bumps the web-components template dependency to `@playcanvas/web-components@^0.17.0` and adapts the starters to its breaking changes:

- **Tag renames** ([playcanvas/web-components#400](https://github.com/playcanvas/web-components/pull/400)): `pc-module` → `pc-wasm` and `pc-rigidbody` → `pc-rigid-body` across the first-person-controller, third-person-controller and physics-playground markup, `whenReady()` selectors and the spawner's HTML template string; `<pc-script name>` → `<pc-script-instance name>` in code comments and the base README.
- **Product configurator orientation fix** ([playcanvas/web-components#397](https://github.com/playcanvas/web-components/pull/397)): `ModelElement.entity` now returns a stable host entity whose transform *composes* with the GLB content beneath it. The starter's `setLocalEulerAngles(-90, -25, 0)` previously *overwrote* lambo.glb's authored −90° X up-axis rotation; composed, it would flip the car upside down. The host now gets only the −25° yaw, which reproduces the exact pre-0.17 world orientation (`Ry(-25)·Rx(-90)`).

## Verification

- Every `pc-*` tag used across all 12 web-components starters checked against 0.17.0's registered element list — no stale tags remain.
- Scaffolded the five affected starters with the built CLI; each installs, lints, typechecks and builds against the published 0.17.0.
- Runtime-checked in a browser: the configurator's car loads (97 mesh instances) with world rotation exactly `(-90, -25, 0)` and grounded auto-fit; the first-person controller boots Ammo through `<pc-wasm>`, creates all 24 rigid bodies and attaches its controller script with no console errors.

## Notes for reviewers

- The vendored `skills/` docs still reference the old tag names, but they sync from [playcanvas/skills](https://github.com/playcanvas/skills) (still at v0.1.0) via the Update Skills workflow, so that fix belongs upstream — local edits would be overwritten on the next sync.
- `playcanvas@^2.21.4` already satisfies 0.17.0's `^2.20.1` peer range, so no engine bump is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)