### PR TITLE
chore: update playcanvas skills to v0.1.1

### DIFF
--- a/skills/assemble-scene/references/web-components.md
+++ b/skills/assemble-scene/references/web-components.md
@@ -4,7 +4,7 @@ Represent the whole gameplay object below one semantic root:
 
 ```html
 <pc-entity name="Enemy_1" position="4 0 -3" rotation="0 90 0">
-    <pc-rigidbody type="dynamic" mass="1"></pc-rigidbody>
+    <pc-rigid-body type="dynamic" mass="1"></pc-rigid-body>
     <pc-collision type="capsule"></pc-collision>
     <pc-entity position="0 0.8 0" rotation="0 180 0" scale="0.01 0.01 0.01">
         <pc-model asset="enemy"></pc-model>
@@ -14,6 +14,6 @@ Represent the whole gameplay object below one semantic root:
 
 Keep component tags as direct children of the owning `<pc-entity>`. Register the model with a
 direct-child `<pc-asset>` under `<pc-app>`. Before using rigid bodies, load Ammo with a direct-child
-`<pc-module name="Ammo">` carrying its `glue`, `wasm`, and `fallback` attributes; `<pc-app>` awaits
+`<pc-wasm name="Ammo">` carrying its `glue`, `wasm`, and `fallback` attributes; `<pc-app>` awaits
 its direct-child modules before creating the graphics device, so every body in the document depends
 on that one element. Add and remove the semantic root as one DOM subtree.

--- a/skills/build-app/references/web-components.md
+++ b/skills/build-app/references/web-components.md
@@ -35,10 +35,10 @@ Build supported application structure declaratively:
 - Treat a present boolean attribute as true unless its value is `false`; remove it to restore the
   Engine default.
 
-Load Engine `Script` modules with `<pc-asset>`, then attach them through `<pc-scripts>` and
-`<pc-script>`. Match the element's `name` to the class's static `scriptName`. Extra kebab-case
-attributes map to camelCase properties; use the `attributes` JSON attribute for nested or reserved
-values.
+Load Engine `Script` modules with `<pc-asset>`, then attach them through `<pc-script>` and
+`<pc-script-instance>`. Match the instance element's `name` to the class's static `scriptName`.
+Extra kebab-case attributes map to camelCase properties; use the `attributes` JSON attribute for
+nested or reserved values.
 
 Use `whenReady` for occasional page-level Engine access:
 

--- a/skills/find-examples/references/web-components.md
+++ b/skills/find-examples/references/web-components.md
@@ -9,7 +9,7 @@ update logic. Drop its graphics device and application bootstrap because `<pc-ap
 - Express supported entities and components with `pc-*` elements.
 - Register assets as direct children of `<pc-app>` with `<pc-asset>`.
 - Put per-entity behavior in an Engine `Script` loaded through `<pc-asset>` and attached with
-  `<pc-scripts>` and `<pc-script>`.
+  `<pc-script>` and `<pc-script-instance>`.
 - Use `whenReady` for page-level glue or Engine APIs with no declarative element.
 - Fetch example assets from the same Engine tag as the source example.
 

--- a/skills/reuse-scripts/references/web-components.md
+++ b/skills/reuse-scripts/references/web-components.md
@@ -8,9 +8,9 @@ Expose an Engine script as an ES module and register it as an asset:
     <pc-scene>
         <pc-entity name="Camera">
             <pc-camera></pc-camera>
-            <pc-scripts>
-                <pc-script name="cameraControls" move-speed="4"></pc-script>
-            </pc-scripts>
+            <pc-script>
+                <pc-script-instance name="cameraControls" move-speed="4"></pc-script-instance>
+            </pc-script>
         </pc-entity>
     </pc-scene>
 </pc-app>


### PR DESCRIPTION
Automated update of the vendored PlayCanvas skills to [`v0.1.1`](https://github.com/playcanvas/skills/releases/tag/v0.1.1).

The [Update Skills workflow run](https://github.com/playcanvas/create-playcanvas/actions/runs/32588826295) synced and pushed this branch, but its `gh pr create` step failed with `Resource not accessible by integration` — the GitHub App token has contents write (the branch push succeeded) but lacks pull-request write permission, so this PR was opened manually. Granting the app **Pull requests: Read & write** on the playcanvas org installation will let future syncs open their PR automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
